### PR TITLE
Cleaned up indentation / standardised comments

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -60,64 +60,57 @@
 <body class="{{body_class}}">
 <div class="wrapper">
 
-<!-- MENU -->
+{{! Menu }}
 {{#if post}}
 <nav class="nav fixed">
 {{else}}
 <nav class="nav">
 {{/if}}
-
-<a id="logo" href="{{@blog.url}}">
-<h1>{{@blog.title}}</h1>
-</a>
-<ul class="nav-primary">
-{{! TODO: Add URLs here }}
-<li><a href="{{@blog.url}}">Home</a></li>
-</ul>
-
+    <a id="logo" href="{{@blog.url}}"><h1>{{@blog.title}}</h1></a>
+    <ul class="nav-primary">
+        {{! TODO: Add URLs here }}
+        <li><a href="{{@blog.url}}">Home</a></li>
+    </ul>
 </nav>
 
 {{! Everything else gets inserted here }}
 {{{body}}}
 
 <footer class="footer">
-  <div class="back-to-top">
-    <a href="">Back to top</a>
-  </div>
-  <div class="footer-nav">
-      <p>{{@blog.title}}</p>
-  </div>
-  <aside class="offsite-links">
-    
-    <a class="twitter-link" href="http://www.twitter.com/{{! TODO: ADD TWITTER HANDLE HERE }}">Twitter</a> /
-    <a class="github-link" href="http://github.com/{{! TODO: ADD GITHUB HANDLE }}">GitHub</a> / 
-    <a class="rss-link" href="{{ @blog.url }}/rss">RSS</a>
-    <p>
-    <a target="_blank" href="https://github.com/roycehaynes/rollsroyce">rollsroyce theme</a> by <a target="_blank" href="http://www.twitter.com/roycehaynes">@roycehaynes</a>
-    </p>
-    Powered by <a target="_blank" href="http://www.ghost.org">Ghost</a>
-  </aside>
-  <!-- javascripts -->
-  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-  <script type="text/javascript" src="{{@blog.url}}/assets/js/fittext.js"></script>
-  <script type="text/javascript" src="{{@blog.url}}/assets/js/app.js"></script>
-  <script type="text/javascript" src="{{@blog.url}}/assets/js/respond.min.js"></script>
+    <div class="back-to-top"><a href="">Back to top</a></div>
+    <div class="footer-nav"><p>{{@blog.title}}</p></div>
 
-  <script type="text/javascript">
-    var ga_ua = '{{! TODO: SET GOOGLE ANALYTICS ID }}';
-
-    (function(g,h,o,s,t,z){g.GoogleAnalyticsObject=s;g[s]||(g[s]=
-        function(){(g[s].q=g[s].q||[]).push(arguments)});g[s].s=+new Date;
-        t=h.createElement(o);z=h.getElementsByTagName(o)[0];
-        t.src='//www.google-analytics.com/analytics.js';
-        z.parentNode.insertBefore(t,z)}(window,document,'script','ga'));
-        ga('create',ga_ua);ga('send','pageview');
-  </script>
-
-  
+    <aside class="offsite-links">
+        <a class="twitter-link" href="http://www.twitter.com/{{! TODO: ADD TWITTER HANDLE HERE }}">Twitter</a> /
+        <a class="github-link" href="http://github.com/{{! TODO: ADD GITHUB HANDLE }}">GitHub</a> / 
+        <a class="rss-link" href="{{ @blog.url }}/rss">RSS</a>
+        <p>
+        <a target="_blank" href="https://github.com/roycehaynes/rollsroyce">rollsroyce theme</a> by <a target="_blank" href="http://www.twitter.com/roycehaynes">@roycehaynes</a>
+        </p>
+        Powered by <a target="_blank" href="http://www.ghost.org">Ghost</a>
+    </aside>
 </footer>
-</div> <!-- end of wrapper -->
+
+</div> {{! End of wrapper }}
+
+{{! Scripts }}
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+<script type="text/javascript" src="{{@blog.url}}/assets/js/fittext.js"></script>
+<script type="text/javascript" src="{{@blog.url}}/assets/js/app.js"></script>
+<script type="text/javascript" src="{{@blog.url}}/assets/js/respond.min.js"></script>
+<script type="text/javascript">
+  var ga_ua = '{{! TODO: SET GOOGLE ANALYTICS ID }}';
+
+  (function(g,h,o,s,t,z){g.GoogleAnalyticsObject=s;g[s]||(g[s]=
+      function(){(g[s].q=g[s].q||[]).push(arguments)});g[s].s=+new Date;
+      t=h.createElement(o);z=h.getElementsByTagName(o)[0];
+      t.src='//www.google-analytics.com/analytics.js';
+      z.parentNode.insertBefore(t,z)}(window,document,'script','ga'));
+      ga('create',ga_ua);ga('send','pageview');
+</script>
+
 {{! Ghost outputs important scripts and data with this tag }}
 {{ghost_foot}}
+
 </body>
 </html>

--- a/index.hbs
+++ b/index.hbs
@@ -4,15 +4,13 @@
         <nav class="art-list">
           <ul class="art-list-body">
             {{#foreach posts }}
-              <li class="art-list-item">
+            <li class="art-list-item">
                 <div class="art-list-item-title-and-time">
-                  <h2 class="art-list-title">
-                    <a href="{{ @blog.url }}{{ url }}">{{ title }}</a>
-                  </h2>
-                  <div class="art-list-time">{{date published_at format="MMMM Do, YYYY"}}</div>
+                    <h2 class="art-list-title"><a href="{{ @blog.url }}{{ url }}">{{ title }}</a></h2>
+                    <div class="art-list-time">{{date published_at format="MMMM Do, YYYY"}}</div>
                 </div>
                 <p>{{excerpt}}</p>
-              </li>
+            </li>
             {{/foreach}}
           </ul>
         </nav>

--- a/post.hbs
+++ b/post.hbs
@@ -2,20 +2,21 @@
 {{#post}}
 
 <article class="art simple {{post_class}}">
-<header class="art-header">
-<div class="art-header-inner" style="margin-top: 0px; opacity: 1;">
-<time class="art-time">{{date published_at format="MMMM Do, YYYY"}}</time>
-<h2 class="art-title">{{title}}</h2>
-<p class="art-subtitle"></p>
-</div>
-</header>
+    
+    <header class="art-header">
+        <div class="art-header-inner" style="margin-top: 0px; opacity: 1;">
+            <time class="art-time">{{date published_at format="MMMM Do, YYYY"}}</time>
+            <h2 class="art-title">{{title}}</h2>
+            <p class="art-subtitle"></p>
+        </div>
+    </header>
 
-<div class="art-body">
-<div class="art-body-inner">
-{{content}}
-</div>
+    <div class="art-body">
+        <div class="art-body-inner">
+            {{content}}
+        </div>
+    </div>
 
-</div>
 </article>
 
 {{/post}}


### PR DESCRIPTION
Was just working on a tweak to see if I could get the title on post.hbs to always be vertically centred whilst maintaining the existing scroll animations. Not quite there yet, but in the mean time I did spot that the HBS files seemed to be a mix of 2, 4 and 0 space indentation - so I moved them all to 4 spaces for readability (also same standard Ghost core uses). And I converted HTML comments to Handlebars comments for cleaner (and smaller) final sourcecode output.

Pedantic changes - but hopefully make everything a little more readable and a little faster.
